### PR TITLE
Add markdown support to esttab

### DIFF
--- a/esttab.ado
+++ b/esttab.ado
@@ -264,6 +264,38 @@ program define esttab
     local booktabs_cilab      `"`macval(tex_cilab)'"'
     local booktabs_substitute `"`macval(tex_substitute)'"'
     local booktabs_interaction `"`macval(tex_interaction)'"'
+// - mmd
+    local mmd_open0          `""'
+    local mmd_close0         `""'
+    local mmd_open           `""""'
+    local mmd_close          `""""'
+    local mmd_caption        `""@title""'
+    local mmd_open2          `""'
+    local mmd_close2         `""'
+    local mmd_toprule        `""""'
+    local mmd_midrule        `""'
+    local mmd_bottomrule     `""""'
+    local mmd_topgap         `""'
+    local mmd_midgap         `""'
+    local mmd_bottomgap      `""'
+    local mmd_eqrule         `""'
+    local mmd_ssl            `"*N* *R*<sup>2</sup> "adj. *R*<sup>2</sup>" "pseudo *R*<sup>2</sup>" *AIC* *BIC*"'
+    local mmd_lsl            `"Observations *R*<sup>2</sup> "Adjusted *R*<sup>2</sup>" "Pseudo *R*<sup>2</sup>" *AIC* *BIC*"'
+    local mmd_starlevels     `"<sup>\*</sup> 0.05 <sup>\*\*</sup> 0.01 <sup>\*\*\*</sup> 0.001"'
+    local mmd_starlevlab     `", label(" *p* < ")"'
+    local mmd_begin          `"| "'
+    local mmd_delimiter      `" | "'
+    local mmd_end            `" |"'
+    local mmd_incelldel      `" "'
+    local mmd_varwidth       `"\`= cond("\`label'"=="", 12, 20)'"'
+    local mmd_modelwidth     `"12"'
+    local mmd_abbrev         `""'
+    local mmd_substitute     `"`"_ \_ "\_cons " \_cons"'"'
+    local mmd_interaction    `"" # ""'
+    local mmd_tstatlab       `"*t* statistics"'
+    local mmd_zstatlab       `"*z* statistics"'
+    local mmd_pvallab        `"*p*-values"'
+    local mmd_cilab          `"\`level'\% confidence intervals"'
 
 // syntax
     syntax [anything] [using] [ , ///
@@ -296,7 +328,7 @@ program define esttab
      ADDNotes(string asis) ///
      COMpress ///
      plain ///
-     smcl FIXed tab csv SCsv rtf HTMl tex BOOKTabs ///
+     smcl FIXed tab csv SCsv rtf HTMl tex BOOKTabs mmd ///
      Fragment ///
      page PAGE2(str) ///
      ALIGNment(str asis) ///
@@ -344,7 +376,7 @@ program define esttab
     }
 
 // format modes
-    local mode `smcl' `fixed' `tab' `csv' `scsv' `rtf' `html' `tex' `booktabs'
+    local mode `smcl' `fixed' `tab' `csv' `scsv' `rtf' `html' `tex' `booktabs' `mmd'
     if `:list sizeof mode'>1 {
         di as err "only one allowed of smcl, fixed, tab, csv, scsv, rtf, html, tex, or booktabs"
         exit 198
@@ -362,6 +394,7 @@ program define esttab
             else if `"`suffix'"'==".csv"             local mode csv
             else if `"`suffix'"'==".rtf"             local mode rtf
             else if `"`suffix'"'==".smcl"            local mode smcl
+            else if `"`suffix'"'==".md"              local mode mmd
             else local mode fixed
         }
         else local mode smcl
@@ -379,6 +412,7 @@ program define esttab
         else if "`mode'"=="html"                  local suffix ".html"
         else if inlist("`mode'","tex","booktabs") local suffix ".tex"
         else if "`mode'"=="smcl"                  local suffix ".smcl"
+        else if "`mode'"=="mmd"                   local suffix ".md"
         local using `"using `"`fn'`suffix'"'"'
         local using0 `" `"`fn'`suffix'"'"'
     }

--- a/esttab.ado
+++ b/esttab.ado
@@ -378,7 +378,7 @@ program define esttab
 // format modes
     local mode `smcl' `fixed' `tab' `csv' `scsv' `rtf' `html' `tex' `booktabs' `mmd'
     if `:list sizeof mode'>1 {
-        di as err "only one allowed of smcl, fixed, tab, csv, scsv, rtf, html, tex, or booktabs"
+        di as err "only one allowed of smcl, fixed, tab, csv, scsv, rtf, html, tex, booktabs, or mmd"
         exit 198
     }
     if `"`using'"'!="" {
@@ -389,12 +389,12 @@ program define esttab
     }
     if "`mode'"=="" {
         if `"`using'"'!="" {
-            if inlist(`"`suffix'"', ".html", ".htm") local mode html
-            else if `"`suffix'"'==".tex"             local mode tex
-            else if `"`suffix'"'==".csv"             local mode csv
-            else if `"`suffix'"'==".rtf"             local mode rtf
-            else if `"`suffix'"'==".smcl"            local mode smcl
-            else if `"`suffix'"'==".md"              local mode mmd
+            if inlist(`"`suffix'"', ".html", ".htm")    local mode html
+            else if `"`suffix'"'==".tex"                local mode tex
+            else if `"`suffix'"'==".csv"                local mode csv
+            else if `"`suffix'"'==".rtf"                local mode rtf
+            else if `"`suffix'"'==".smcl"               local mode smcl
+            else if inlist(`"`suffix'"', ".md", ".mmd") local mode mmd
             else local mode fixed
         }
         else local mode smcl
@@ -422,6 +422,9 @@ program define esttab
     else if "`mode0'"=="csv" {
         if "`plain'"=="" local csvlhs `"=""'
         else local csvlhs `"""'
+    }
+    else if "`mode0'"=="mmd" {
+        local style "style(mmd)"
     }
     if "`compress'"!="" {
         if "``mode'_modelwidth'"!="" {


### PR DESCRIPTION
Hi Ben,

I have been working on adding support for markdown output to esttab. I have run into some issues I was hoping you could help with.

Running this code:

```
sysuse auto
reg price trunk 
esttab, mmd style(mmd) title(A Markdown Table in Stata) nonumbers
```

produces this output:

```

A Markdown Table in Stata

|              |        price                  |
| ------------ | :---------------------------: |
| trunk        |        216.7<sup>\*\*</sup>   |
|              |       (2.81)                  |
| _cons        |       3183.5<sup>\*\*</sup>   |
|              |       (2.87)                  |
| *N*          |           74                  |

*t* statistics in parentheses
<sup>\*</sup> *p* < 0.05, <sup>\*\*</sup> *p* < 0.01, <sup>\*\*\*</sup> *p* < 0.001
```

which translates into a valid markdown table:

A Markdown Table in Stata

|              |        price                  |
| ------------ | :---------------------------: |
| trunk        |        216.7<sup>\*\*</sup>   |
|              |       (2.81)                  |
| _cons        |       3183.5<sup>\*\*</sup>   |
|              |       (2.87)                  |
| *N*          |           74                  |

*t* statistics in parentheses
<sup>\*</sup> *p* < 0.05, <sup>\*\*</sup> *p* < 0.01, <sup>\*\*\*</sup> *p* < 0.001

I have two issues:
1. I couldn't pass the ```mmd``` style from esttab to estout to make it write the header row options. It looks like esttab automatically sets the style to ```esttab``` but the ```mmd``` style is required for the header row to be processed correctly.
2. Adding two or more outputs to the header cells breaks the markdown tables because markdown expects only one header row. A workaround would be to separate each element in the header cells with ```<br>``` like this:

```
|              |        (1) <br> price         |
| ------------ | :---------------------------: |
| trunk        |        216.7<sup>\*\*</sup>   |
|              |       (2.81)                  |
| _cons        |       3183.5<sup>\*\*</sup>   |
|              |       (2.87)                  |
| *N*          |           74                  |
```

|              |        (1) <br> price         |
| ------------ | :---------------------------: |
| trunk        |        216.7<sup>\*\*</sup>   |
|              |       (2.81)                  |
| _cons        |       3183.5<sup>\*\*</sup>   |
|              |       (2.87)                  |
| *N*          |           74                  |

I tried to look at the estout code that puts together the table headers but I couldn't make much progress in adjusting it.

Any guidance is much appreciated!